### PR TITLE
cargo: update homepage to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Vincent Rischmann <vincent@rischmann.fr>"]
 description = "Run a git command in all repositories under the current working directory"
 readme = "README.md"
-homepage = "https://github.com/vrischmann/gitjuggling"
+repository = "https://github.com/vrischmann/gitjuggling"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂